### PR TITLE
[chore] Update main branch name in GHA

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -10,7 +10,7 @@ on:
 
   pull_request:
     branches: 
-      - master
+      - main
       - release/**
 
   workflow_dispatch:


### PR DESCRIPTION
This PR updates the branches enumeration sensitive to start `build_and_deploy` workflow on pull requests as the main branch name has been changed.

If this branch would not have been done, the PR's open to `main` branch wouldn't trigger the necessary workflow.