### PR TITLE
[fix] Use Correct OTLP Port Number in Exporters

### DIFF
--- a/extension/solarwindsextension/internal/config.go
+++ b/extension/solarwindsextension/internal/config.go
@@ -136,9 +136,9 @@ func (cfg *Config) EndpointUrl() (string, error) {
 // dataCenterToURLMapping maps a data center ID to
 // to its corresponding OTLP endpoint URL.
 var dataCenterToURLMapping = map[string]string{
-	"na-01": "otel.collector.na-01.cloud.solarwinds.com:4317",
-	"na-02": "otel.collector.na-02.cloud.solarwinds.com:4317",
-	"eu-01": "otel.collector.eu-01.cloud.solarwinds.com:4317",
+	"na-01": "otel.collector.na-01.cloud.solarwinds.com:443",
+	"na-02": "otel.collector.na-02.cloud.solarwinds.com:443",
+	"eu-01": "otel.collector.eu-01.cloud.solarwinds.com:443",
 }
 
 // lookupDataCenterURL returns the OTLP endpoint URL

--- a/extension/solarwindsextension/internal/datacell_test.go
+++ b/extension/solarwindsextension/internal/datacell_test.go
@@ -31,10 +31,10 @@ func TestConfigValidateDataCenters(t *testing.T) {
 	}
 
 	tests := []test{
-		{dataCenter: "na-01", url: "otel.collector.na-01.cloud.solarwinds.com:4317", ok: true},
-		{dataCenter: "na-02", url: "otel.collector.na-02.cloud.solarwinds.com:4317", ok: true},
-		{dataCenter: "eu-01", url: "otel.collector.eu-01.cloud.solarwinds.com:4317", ok: true},
-		{dataCenter: "NA-01", url: "otel.collector.na-01.cloud.solarwinds.com:4317", ok: true},
+		{dataCenter: "na-01", url: "otel.collector.na-01.cloud.solarwinds.com:443", ok: true},
+		{dataCenter: "na-02", url: "otel.collector.na-02.cloud.solarwinds.com:443", ok: true},
+		{dataCenter: "eu-01", url: "otel.collector.eu-01.cloud.solarwinds.com:443", ok: true},
+		{dataCenter: "NA-01", url: "otel.collector.na-01.cloud.solarwinds.com:443", ok: true},
 		{dataCenter: "apj-01", url: "", ok: false},
 	}
 


### PR DESCRIPTION
#### Description
The OTLP port number for SolarWinds SaaS is `443`, not `4317`. Apparently, it was replaced by mistake during recent changes.

#### Testing
It was tested locally by building a Docker image from this branch and running it against SolarWinds SaaS (`na-01`).

