### PR TITLE
[test] Use Self-Signed Certificates to Use Exporter with TLS in E2E Tests

### DIFF
--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -3,6 +3,7 @@ module github.com/solarwinds/solarwinds-otel-collector/internal/e2e
 go 1.23.4
 
 require (
+	github.com/mdelapenya/tlscert v0.1.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.34.0
 	go.opentelemetry.io/collector/pdata v1.19.0

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -66,6 +66,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mdelapenya/tlscert v0.1.0 h1:YTpF579PYUX475eOL+6zyEO3ngLTOUWck78NBuJVXaM=
+github.com/mdelapenya/tlscert v0.1.0/go.mod h1:wrbyM/DwbFCeCeqdPX/8c6hNOqQgbf0rUDErE1uD+64=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=

--- a/internal/e2e/signals_processing_test.go
+++ b/internal/e2e/signals_processing_test.go
@@ -27,13 +27,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/network"
 )
 
 const (
@@ -48,11 +47,15 @@ func TestMetricStream(t *testing.T) {
 	require.NoError(t, err)
 	testcontainers.CleanupNetwork(t, net)
 
-	rContainer, err := runReceivingSolarWindsOTELCollector(ctx, net.Name)
+	certPath := t.TempDir()
+	_, err = generateCertificates(receivingContainer, certPath)
+	require.NoError(t, err)
+
+	rContainer, err := runReceivingSolarWindsOTELCollector(ctx, certPath, net.Name)
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, rContainer)
 
-	eContainer, err := runTestedSolarWindsOTELCollector(ctx, net.Name)
+	eContainer, err := runTestedSolarWindsOTELCollector(ctx, certPath, net.Name)
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, eContainer)
 
@@ -80,11 +83,15 @@ func TestTracesStream(t *testing.T) {
 	require.NoError(t, err)
 	testcontainers.CleanupNetwork(t, net)
 
-	rContainer, err := runReceivingSolarWindsOTELCollector(ctx, net.Name)
+	certPath := t.TempDir()
+	_, err = generateCertificates(receivingContainer, certPath)
+	require.NoError(t, err)
+
+	rContainer, err := runReceivingSolarWindsOTELCollector(ctx, certPath, net.Name)
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, rContainer)
 
-	eContainer, err := runTestedSolarWindsOTELCollector(ctx, net.Name)
+	eContainer, err := runTestedSolarWindsOTELCollector(ctx, certPath, net.Name)
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, eContainer)
 
@@ -114,11 +121,15 @@ func TestLogsStream(t *testing.T) {
 	require.NoError(t, err)
 	testcontainers.CleanupNetwork(t, net)
 
-	rContainer, err := runReceivingSolarWindsOTELCollector(ctx, net.Name)
+	certPath := t.TempDir()
+	_, err = generateCertificates(receivingContainer, certPath)
+	require.NoError(t, err)
+
+	rContainer, err := runReceivingSolarWindsOTELCollector(ctx, certPath, net.Name)
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, rContainer)
 
-	eContainer, err := runTestedSolarWindsOTELCollector(ctx, net.Name)
+	eContainer, err := runTestedSolarWindsOTELCollector(ctx, certPath, net.Name)
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, eContainer)
 

--- a/internal/e2e/testdata/emitting_collector.yaml
+++ b/internal/e2e/testdata/emitting_collector.yaml
@@ -22,7 +22,6 @@ extensions:
     token: <no-matter-in-test>
     collector_name: "testing_collector_name"
     endpoint_url_override: receiver:17016
-    insecure: true
 
 exporters:
   solarwinds:

--- a/internal/e2e/testdata/receiving_collector.yaml
+++ b/internal/e2e/testdata/receiving_collector.yaml
@@ -15,6 +15,9 @@ receivers:
     protocols:
       grpc: 
         endpoint: :17016
+        tls:
+          cert_file: /opt/cert-server.pem
+          key_file: /opt/key-server.pem
 exporters:
   file:
     path: /tmp/result.json


### PR DESCRIPTION
#### Description
This PR enables TLS in E2E tests. 
It achieves that by generating self-signed certificates during the tests to be used by the **test OTLP/gRPC Receiver** together with a root certificate added as trusted to the **tested solarwinds-otel-collector** container. 

##### Note
- The current version overwrites `/etc/ssl/certs/ca-certificates.crt` in the Distroless image instead of only appending the generated test root certificate for simplicity. The image is stripped to a bare minimum and it's trickier to add it properly without modifying the actual image (Dockerfile).
- The `insecure` flag is not removed in this PR.

#### Testing
E2E tests passing.
