### PR TITLE
docs: Add Naming Guidelines

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+    commit-message:
+      prefix: "chore: "
   - package-ecosystem: docker
     directory: /build/docker
     labels:
@@ -17,6 +19,8 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+    commit-message:
+      prefix: "chore: "
   - package-ecosystem: gomod
     directories:
       - /cmd
@@ -42,3 +46,5 @@ updates:
         update-types:
         - "patch"
         - "minor"
+    commit-message:
+      prefix: "chore: "

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ ! ${PR_TITLE} =~ ^(build|ci|chore|docs|feature|fix|perf|refactor|style|test): (#\d+ ){0,1}((?![ ,#]).*)$ ]]; then
+            echo "::error::Invalid Pull Request title. Please update it according to guidelines: https://github.com/solarwinds/solarwinds-otel-collector/docs/development-guidelines.md#pull-requests"
+            exit 1
+          fi
       - name: Check licenses
         run: make ci-check-licenses
 

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -24,14 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check PR title
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if [[ ! ${PR_TITLE} =~ ^(build|ci|chore|docs|feature|fix|perf|refactor|style|test): (#\d+ ){0,1}((?![ ,#]).*)$ ]]; then
-            echo "::error::Invalid Pull Request title. Please update it according to guidelines: https://github.com/solarwinds/solarwinds-otel-collector/docs/development-guidelines.md#pull-requests"
-            exit 1
-          fi
       - name: Check licenses
         run: make ci-check-licenses
 

--- a/.github/workflows/checkPullRequestSemantics.yml
+++ b/.github/workflows/checkPullRequestSemantics.yml
@@ -1,0 +1,25 @@
+name: Check Pull Request Semantics
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/**
+    types:
+      - opened
+      - edited
+
+  workflow_dispatch:
+
+jobs:
+  check_semantics:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR title
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        if [[ ! ${PR_TITLE} =~ ^(build|ci|chore|docs|feature|fix|perf|refactor|style|test):[[:space:]](#[[:digit:]]+[[:space:]]){0,1}([^ ,#].*)$ ]]; then
+          echo "::error::Invalid Pull Request title. Please update it according to guidelines: https://github.com/solarwinds/solarwinds-otel-collector/docs/development-guidelines.md#pull-requests"
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ and [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentele
 
 Get the image from DockerHub.
 
-`docker pull solarwinds/solarwinds-otel-collector:0.113.2`
+`docker pull solarwinds/solarwinds-otel-collector:latest`
 
 To run the image utilize following command:
 
-`docker run  -v ./your_config_file.yaml:/opt/default-config.yaml solarwinds-otel-collector:0.113.2`
+`docker run  -v ./your_config_file.yaml:/opt/default-config.yaml solarwinds-otel-collector:latest`
 
 See [complete docker documentation](./build/docker/README.md).
 

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -7,7 +7,7 @@ Docker image for _SolarWinds OpenTelemetry Collector_:
 ## Getting the Image
 Pull the image from DockerHub.
 
-`docker pull solarwinds/solarwinds-otel-collector:0.113.2`
+`docker pull solarwinds/solarwinds-otel-collector:latest`
 
 Optionally you can build the image yourself, simply run docker build command, i.e.
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -11,8 +11,8 @@ _Example:_ `chore/#12-update-dependency-version`
 
 As for individual parts of the branch name:
 - _type_ should reflect the types described in [Commits](#commits) section
-- _issue-number_ should refer to [GitHub Issue](https://github.com/solarwinds/solarwinds-otel-collector/issues) number from this project the changes in the branch address. If such issue does not exist (i.e. for immediate fixes) this part starting with hash should be omitted
-- _description-of-changes_ should provide meaningful description of changes the branch holds, with words separated by dashes (i.e. title of related GitHub Issue, or its respective sub-part)
+- _issue-number_ should refer to related [GitHub Issue](https://github.com/solarwinds/solarwinds-otel-collector/issues) number. If such issue does not exist (i.e. for immediate fixes) this part starting with hash should be omitted
+- _description-of-changes_ should provide meaningful description of changes the branch holds, with words separated by dashes (i.e. title of related [GitHub Issue](https://github.com/solarwinds/solarwinds-otel-collector/issues), or its respective sub-part)
 
 ### Commits
 Commit naming in general should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) conventions. Please refer to related [documentation](https://www.conventionalcommits.org/en/v1.0.0/) for the specification with examples.

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -23,7 +23,7 @@ For feature-altering commits utilize `feature` over `feat` type name.
 _Example:_ `feature: add collector_name parameter to solarwindsextension`
 
 > [!WARNING]  
-> Please pay extra attention to commit naming when creating a squash merge commits to protected branches.
+> Please pay extra attention to commit naming when creating squash merge commits to protected branches.
 
 ### Pull Requests
 Pull requests should reflect [branch name](#branches) they are created from. If the branch name is not descriptive enough, the pull request title should be adjusted to be as descriptive as possible. The format should be following:

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -1,0 +1,38 @@
+# Development Guidelines
+
+## Naming
+
+### Branches
+Name of the branches created within this repository should follow the following format:
+
+`{type}/#{issue-number}-{description-of-changes}`
+
+_Example:_ `chore/#12-update-dependency-version`
+
+As for individual parts of the branch name:
+- _type_ should reflect the types described in [Commits](#commits) section
+- _issue-number_ should refer to [GitHub Issue](https://github.com/solarwinds/solarwinds-otel-collector/issues) number from this project the changes in the branch address. If such issue does not exist (i.e. for immediate fixes) this part starting with hash should be omitted
+- _description-of-changes_ should provide meaningful description of changes the branch holds, with words separated by dashes (i.e. title of related GitHub Issue, or its respective sub-part)
+
+### Commits
+Commit naming in general should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) conventions. Please refer to related [documentation](https://www.conventionalcommits.org/en/v1.0.0/) for the specification with examples.
+
+For _type_ part of the commit message, utilize the full palette of suggested types based of [Angular conventions](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type). 
+For feature-altering commits utilize `feature` over `feat` type name.
+
+_Example:_ `feature: add collector_name parameter to solarwindsextension`
+
+> [!WARNING]  
+> Please pay extra attention to commit naming when creating a squash merge commits to protected branches.
+
+### Pull Requests
+Pull requests should reflect [branch name](#branches) they are created from. If the branch name is not descriptive enough, the pull request title should be adjusted to be as descriptive as possible. The format should be following:
+
+`{type}: #{issue number} {Description of Changes}`
+
+_Example:_ 
+* branch name: `chore/#12-update-dependency-version`
+* pull request title: `chore: #12 Update Dependency Version`
+
+### Code
+Naming within code should in general follow principles laid out by [Effective Go](https://go.dev/doc/effective_go) with having [OpenTelemetry naming conventions](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/coding-guidelines.md#naming-convention) in mind.


### PR DESCRIPTION
#### Description
Created general document with development guidelines and expanded on naming conventions.

There is on difference to what was originally discussed for _Pull Requests_. The original proposal was to have
`[type]: #{issue number} Description of Changes` format.
Looking at the commit history in main I propose to keep the commit format:
`{type}: #{issue number} Description of Changes` (note the missing brackets), because the main squash commit option when merging by default **takes the title as commit message** using the brackets.. and this already led to disalignment. So I think sticking to this naming will provide more reliable commit naming outputs in main (which should be the main concern).

Also added new 'Check Pull Request Semantics' workflow to check correct semantics of the PR: 
- it should fail if the title is incorrect at this point. 
- added as separate workflow to have better flexibility: possibility to trigger on PR title update (we don't want to ie. trigger builds with that). 
- see example of failure here: https://github.com/solarwinds/solarwinds-otel-collector/actions/runs/12598763679/job/35114291997?pr=16
- one potential downside is that it is triggered on _any edit_ - ie. description change. This is current limitation of GHA workflows. We might just leave it to be checked for opened PR and then defer to manual rerun if that should be an issue - yet that would not deal with the negative scenario when the check is green and PR title is changed - it would never be re-checked if not triggered manually again. 

<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector/issues/XXXX
-->

#### Testing
N/A, docs only change.