### PR TITLE
feature: Append Collector Name to All Exported Signals in Exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.113.6
+Mark all outgoing telemetry from the [SolarWinds Exporter](./exporter/solarwindsexporter) with
+an attribute storing the collector name (`sw.otelcol.collector.name`) as it is configured in the
+[SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started).
+
 ## v0.113.5
 Tags released docker images with `latest` tag.
 

--- a/exporter/solarwindsexporter/config.go
+++ b/exporter/solarwindsexporter/config.go
@@ -41,10 +41,13 @@ type Config struct {
 	// Timeout configures timeout in the underlying OTLP exporter.
 	Timeout exporterhelper.TimeoutConfig `mapstructure:"timeout,squash"`
 
-	// ingestionToken stores the token provided by the Solarwinds Extension.
+	// Fields below populated from Solarwinds Extension at runtime:
+	// ingestionToken stores the token used to export telemetry.
 	ingestionToken configopaque.String `mapstructure:"-"`
-	// endpointURL stores the URL provided by the Solarwinds Extension.
+	// endpointURL stores the URL for exporting telemetry.
 	endpointURL string `mapstructure:"-"`
+	// collectorName is added as an attribute to telemetry.
+	collectorName string `mapstructure:"-"`
 }
 
 // extensionAsComponent tries to parse `extension` value of the form 'type/name'

--- a/exporter/solarwindsexporter/solarwinds_exporter.go
+++ b/exporter/solarwindsexporter/solarwinds_exporter.go
@@ -37,6 +37,10 @@ const (
 	tracesExporterType
 )
 
+// collectorNameAttribute is a resource attribute appended
+// to all exported telemetry signals.
+const collectorNameAttribute = "sw.otelcol.collector.name"
+
 var (
 	ErrSwiExtensionNotFound = errors.New("solarwinds extension not found")
 )
@@ -69,6 +73,51 @@ func newExporter(
 	return swiExporter, nil
 }
 
+// initCommonCfgFromExtension tries to locate an instance
+// of the SolarWinds Extension. If successful, it obtains
+// the common configuration from the extension and uses
+// the received configuration to initialize the part of exporter's
+// configuration that is common.
+func (swiExporter *solarwindsExporter) initCommonCfgFromExtension(
+	host component.Host,
+	extensionID *component.ID,
+) error {
+	// Only allow the type of the [solarwindsextension].
+	if extensionID != nil &&
+		extensionID.Type() != solarwindsextension.NewFactory().Type() {
+		return fmt.Errorf("unexpected extension type: %s", extensionID.Type())
+	}
+
+	// Find the SolarWinds Extension.
+	swiExtension := findExtension(host.GetExtensions(), extensionID)
+	if swiExtension == nil {
+		if extensionID != nil {
+			return fmt.Errorf("solarwinds extension %q not found", extensionID)
+		}
+		return ErrSwiExtensionNotFound
+	}
+
+	// Obtain common configuration from the extension.
+	commonCfg := swiExtension.GetCommonConfig()
+
+	// Get token from the extension.
+	token := commonCfg.Token()
+	swiExporter.config.ingestionToken = token
+
+	// Get URL from the extension.
+	url, err := commonCfg.Url()
+	if err != nil {
+		return fmt.Errorf("URL configuration not available: %w", err)
+	}
+	swiExporter.config.endpointURL = url
+
+	// Get collector name from the extension.
+	collectorName := commonCfg.CollectorName()
+	swiExporter.config.collectorName = collectorName
+
+	return nil
+}
+
 func (swiExporter *solarwindsExporter) initExporterType(
 	ctx context.Context,
 	settings exporter.Settings,
@@ -81,32 +130,10 @@ func (swiExporter *solarwindsExporter) initExporterType(
 		return fmt.Errorf("failed parsing extension id: %w", err)
 	}
 
-	// Only allow the type of the [solarwindsextension].
-	if extensionID != nil &&
-		extensionID.Type() != solarwindsextension.NewFactory().Type() {
-		return fmt.Errorf("unexpected extension type: %s", extensionID.Type())
-	}
-
-	swiExtension := findExtension(host.GetExtensions(), extensionID)
-	if swiExtension == nil {
-		if extensionID != nil {
-			return fmt.Errorf("solarwinds extension %q not found", extensionID)
-		}
-		return ErrSwiExtensionNotFound
-	}
-
-	endpointCfg := swiExtension.GetEndpointConfig()
-
-	// Get token from the extensions.
-	token := endpointCfg.Token()
-	swiExporter.config.ingestionToken = token
-
-	// Get URL from the extension.
-	url, err := endpointCfg.Url()
+	err = swiExporter.initCommonCfgFromExtension(host, extensionID)
 	if err != nil {
-		return fmt.Errorf("URL configuration not available: %w", err)
+		return fmt.Errorf("failed to init common config from extension: %w", err)
 	}
-	swiExporter.config.endpointURL = url
 
 	otlpExporter := otlpexporter.NewFactory()
 	otlpCfg, err := swiExporter.config.OTLPConfig()
@@ -207,6 +234,15 @@ func (swiExporter *solarwindsExporter) pushMetrics(ctx context.Context, metrics 
 		return nil
 	}
 
+	// Decorate all metrics with a collector name for easy grouping.
+	for i, rms := 0, metrics.ResourceMetrics(); i < rms.Len(); i++ {
+		resource := rms.At(i).Resource()
+		resource.Attributes().PutStr(
+			collectorNameAttribute,
+			swiExporter.config.collectorName,
+		)
+	}
+
 	return swiExporter.metrics.ConsumeMetrics(ctx, metrics)
 }
 
@@ -215,12 +251,30 @@ func (swiExporter *solarwindsExporter) pushLogs(ctx context.Context, logs plog.L
 		return nil
 	}
 
+	// Decorate all logs with a collector name for easy grouping.
+	for i, rls := 0, logs.ResourceLogs(); i < rls.Len(); i++ {
+		resource := rls.At(i).Resource()
+		resource.Attributes().PutStr(
+			collectorNameAttribute,
+			swiExporter.config.collectorName,
+		)
+	}
+
 	return swiExporter.logs.ConsumeLogs(ctx, logs)
 }
 
 func (swiExporter *solarwindsExporter) pushTraces(ctx context.Context, traces ptrace.Traces) error {
 	if traces.SpanCount() == 0 {
 		return nil
+	}
+
+	// Decorate all traces with a collector name for easy grouping.
+	for i, rss := 0, traces.ResourceSpans(); i < rss.Len(); i++ {
+		resource := rss.At(i).Resource()
+		resource.Attributes().PutStr(
+			collectorNameAttribute,
+			swiExporter.config.collectorName,
+		)
 	}
 
 	return swiExporter.traces.ConsumeTraces(ctx, traces)

--- a/exporter/solarwindsexporter/solarwinds_exporter.go
+++ b/exporter/solarwindsexporter/solarwinds_exporter.go
@@ -37,10 +37,6 @@ const (
 	tracesExporterType
 )
 
-// collectorNameAttribute is a resource attribute appended
-// to all exported telemetry signals.
-const collectorNameAttribute = "sw.otelcol.collector.name"
-
 var (
 	ErrSwiExtensionNotFound = errors.New("solarwinds extension not found")
 )
@@ -238,7 +234,7 @@ func (swiExporter *solarwindsExporter) pushMetrics(ctx context.Context, metrics 
 	for i, rms := 0, metrics.ResourceMetrics(); i < rms.Len(); i++ {
 		resource := rms.At(i).Resource()
 		resource.Attributes().PutStr(
-			collectorNameAttribute,
+			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
 	}
@@ -255,7 +251,7 @@ func (swiExporter *solarwindsExporter) pushLogs(ctx context.Context, logs plog.L
 	for i, rls := 0, logs.ResourceLogs(); i < rls.Len(); i++ {
 		resource := rls.At(i).Resource()
 		resource.Attributes().PutStr(
-			collectorNameAttribute,
+			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
 	}
@@ -272,7 +268,7 @@ func (swiExporter *solarwindsExporter) pushTraces(ctx context.Context, traces pt
 	for i, rss := 0, traces.ResourceSpans(); i < rss.Len(); i++ {
 		resource := rss.At(i).Resource()
 		resource.Attributes().PutStr(
-			collectorNameAttribute,
+			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
 	}

--- a/extension/solarwindsextension/README.md
+++ b/extension/solarwindsextension/README.md
@@ -20,7 +20,7 @@ It provides these features:
     - The value is a time from the start of the collector in seconds
   - This signal is necessary for SolarWinds Observability SaaS to detect the collector when installed and to determine if it's still alive.
   - It also contains some additional information as resource attributes for SolarWinds Observability SaaS:
-    - Collector name: `sw.collector.name`
+    - Collector name: `sw.otelcol.collector.name`
 
 ## Getting Started
 
@@ -38,7 +38,7 @@ extensions:
 ```
 - `token` (mandatory) - You can generate your token in your SolarWinds Observability SaaS account under _Settings / API Tokens / Create API Token_. The type is "Ingestion". You can find the complete documentation [here](https://documentation.solarwinds.com/en/success_center/observability/content/settings/api-tokens.htm).
 - `data_center` (mandatory) - Data center is the region you picked during the sign-up process. You can easily see in URLs after logging in to SolarWinds Observability SaaS - it's either `na-01`, `na-02` or `eu-01`. Please refer to the [documentation](https://documentation.solarwinds.com/en/success_center/observability/content/system_requirements/endpoints.htm#Find) for details.
-- `collector_name` (mandatory) - The collector name passed in the heartbeat metric (as `sw.collector.name` resource attribute) to identify the collector. Doesn't have to be unique.
+- `collector_name` (mandatory) - The collector name passed in the heartbeat metric (as `sw.otelcol.collector.name` resource attribute) to identify the collector. Doesn't have to be unique.
 - `resource` (optional) - You can specify additional attributes to be added to the `sw.otecol.uptime` metric. 
 ## Development
 - **Tests** can be executed with `make test`.

--- a/extension/solarwindsextension/common_config.go
+++ b/extension/solarwindsextension/common_config.go
@@ -30,7 +30,7 @@ type commonConfig struct{ cfg *internal.Config }
 
 var _ CommonConfig = (*commonConfig)(nil)
 
-func newEndpointConfig(cfg *internal.Config) *commonConfig {
+func newCommonConfig(cfg *internal.Config) *commonConfig {
 	return &commonConfig{cfg: cfg}
 }
 

--- a/extension/solarwindsextension/endpoint_config.go
+++ b/extension/solarwindsextension/endpoint_config.go
@@ -20,23 +20,28 @@ import (
 	"github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension/internal"
 )
 
-type EndpointConfig interface {
+type CommonConfig interface {
 	Url() (string, error)
 	Token() configopaque.String
+	CollectorName() string
 }
 
-type endpointConfig struct{ cfg *internal.Config }
+type commonConfig struct{ cfg *internal.Config }
 
-var _ EndpointConfig = (*endpointConfig)(nil)
+var _ CommonConfig = (*commonConfig)(nil)
 
-func newEndpointConfig(cfg *internal.Config) *endpointConfig {
-	return &endpointConfig{cfg: cfg}
+func newEndpointConfig(cfg *internal.Config) *commonConfig {
+	return &commonConfig{cfg: cfg}
 }
 
-func (c *endpointConfig) Url() (string, error) {
+func (c *commonConfig) Url() (string, error) {
 	return c.cfg.EndpointUrl()
 }
 
-func (c *endpointConfig) Token() configopaque.String {
+func (c *commonConfig) Token() configopaque.String {
 	return c.cfg.IngestionToken
+}
+
+func (c *commonConfig) CollectorName() string {
+	return c.cfg.CollectorName
 }

--- a/extension/solarwindsextension/extension.go
+++ b/extension/solarwindsextension/extension.go
@@ -47,7 +47,7 @@ func newExtension(ctx context.Context, set extension.Settings, cfg *internal.Con
 	return e, nil
 }
 
-func (e *SolarwindsExtension) GetEndpointConfig() EndpointConfig { return newEndpointConfig(e.config) }
+func (e *SolarwindsExtension) GetCommonConfig() CommonConfig { return newEndpointConfig(e.config) }
 
 func (e *SolarwindsExtension) Start(ctx context.Context, host component.Host) error {
 	e.logger.Info("Starting Solarwinds Extension")

--- a/extension/solarwindsextension/extension.go
+++ b/extension/solarwindsextension/extension.go
@@ -24,6 +24,10 @@ import (
 	"github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension/internal"
 )
 
+// CollectorNameAttribute is a resource attribute
+// representing the configured name of the collector.
+const CollectorNameAttribute = internal.CollectorNameAttribute
+
 type SolarwindsExtension struct {
 	logger    *zap.Logger
 	config    *internal.Config
@@ -47,7 +51,7 @@ func newExtension(ctx context.Context, set extension.Settings, cfg *internal.Con
 	return e, nil
 }
 
-func (e *SolarwindsExtension) GetCommonConfig() CommonConfig { return newEndpointConfig(e.config) }
+func (e *SolarwindsExtension) GetCommonConfig() CommonConfig { return newCommonConfig(e.config) }
 
 func (e *SolarwindsExtension) Start(ctx context.Context, host component.Host) error {
 	e.logger.Info("Starting Solarwinds Extension")

--- a/extension/solarwindsextension/internal/heartbeat.go
+++ b/extension/solarwindsextension/internal/heartbeat.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	defaultHeartbeatInterval = 30 * time.Second
+	CollectorNameAttribute   = "sw.otelcol.collector.name"
 )
 
 type MetricsExporter interface {
@@ -161,7 +162,7 @@ func (h *Heartbeat) decorateResourceAttributes(resource pcommon.Resource) error 
 	}
 
 	if h.collectorName != "" {
-		resource.Attributes().PutStr("sw.otelcol.collector.name", h.collectorName)
+		resource.Attributes().PutStr(CollectorNameAttribute, h.collectorName)
 	}
 	return nil
 }

--- a/internal/e2e/signals_processing_test.go
+++ b/internal/e2e/signals_processing_test.go
@@ -36,8 +36,10 @@ import (
 )
 
 const (
-	resourceAttributeName  = "resource.attributes.testing_attribute"
-	resourceAttributeValue = "testing_value"
+	resourceAttributeName       = "resource.attributes.testing_attribute"
+	resourceAttributeValue      = "testing_value"
+	collectorNameAttributeName  = "sw.otelcol.collector.name"
+	collectorNameAttributeValue = "testing_collector_name"
 )
 
 func TestMetricStream(t *testing.T) {
@@ -281,9 +283,20 @@ func evaluateResourceAttributes(
 	t *testing.T,
 	atts pcommon.Map,
 ) {
+	// Evaluate testing attribute.
 	val, ok := atts.Get(resourceAttributeName)
 	require.True(t, ok, "testing attribute must exist")
 	require.Equal(t, val.AsString(), resourceAttributeValue, "testing attribute value must be the same")
+
+	// Evaluate collector name as an attribute.
+	val, ok = atts.Get(collectorNameAttributeName)
+	require.True(t, ok, "collector name attribute must exist")
+	require.Equal(
+		t,
+		val.AsString(),
+		collectorNameAttributeValue,
+		"collector name attribute value must be as configured",
+	)
 }
 
 func loadResultFile(


### PR DESCRIPTION
#### Description
This PR introduces a new resource attribute `sw.otelcol.collector.name` with the collector name as its value appended to all telemetry signals exporter from the Solarwinds Exporter.

#### Testing
It is tested in the `internal/e2e/signals_processing_test.go`