### PR TITLE
feature: tag all signals with entity_creation attribute

### DIFF
--- a/exporter/solarwindsexporter/config.go
+++ b/exporter/solarwindsexporter/config.go
@@ -47,8 +47,8 @@ type Config struct {
 	// endpointURL stores the URL for exporting telemetry.
 	endpointURL string `mapstructure:"-"`
 	// collectorName is added as an attribute to telemetry.
-	collectorName  string `mapstructure:"-"`
-	entityCreation string `mapstructure:"-"`
+	collectorName string `mapstructure:"-"`
+	withoutEntity bool   `mapstructure:"-"`
 }
 
 // extensionAsComponent tries to parse `extension` value of the form 'type/name'

--- a/exporter/solarwindsexporter/config.go
+++ b/exporter/solarwindsexporter/config.go
@@ -47,7 +47,8 @@ type Config struct {
 	// endpointURL stores the URL for exporting telemetry.
 	endpointURL string `mapstructure:"-"`
 	// collectorName is added as an attribute to telemetry.
-	collectorName string `mapstructure:"-"`
+	collectorName  string `mapstructure:"-"`
+	entityCreation string `mapstructure:"-"`
 }
 
 // extensionAsComponent tries to parse `extension` value of the form 'type/name'

--- a/exporter/solarwindsexporter/solarwinds_exporter.go
+++ b/exporter/solarwindsexporter/solarwinds_exporter.go
@@ -39,6 +39,7 @@ const (
 
 var (
 	ErrSwiExtensionNotFound = errors.New("solarwinds extension not found")
+	EntityCreationOnValue   = "on"
 )
 
 type solarwindsExporter struct {
@@ -109,13 +110,8 @@ func (swiExporter *solarwindsExporter) initCommonCfgFromExtension(
 
 	// Get collector name from the extension.
 	collectorName := commonCfg.CollectorName()
-	withoutEntity := commonCfg.WithoutEntity()
 	swiExporter.config.collectorName = collectorName
-	if withoutEntity {
-		swiExporter.config.entityCreation = "off"
-	} else {
-		swiExporter.config.entityCreation = "on"
-	}
+	swiExporter.config.withoutEntity = commonCfg.WithoutEntity()
 
 	return nil
 }
@@ -243,10 +239,12 @@ func (swiExporter *solarwindsExporter) pushMetrics(ctx context.Context, metrics 
 			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
-		resource.Attributes().PutStr(
-			solarwindsextension.EntityCreation,
-			swiExporter.config.entityCreation,
-		)
+		if !swiExporter.config.withoutEntity {
+			resource.Attributes().PutStr(
+				solarwindsextension.EntityCreation,
+				EntityCreationOnValue,
+			)
+		}
 	}
 
 	return swiExporter.metrics.ConsumeMetrics(ctx, metrics)
@@ -264,10 +262,12 @@ func (swiExporter *solarwindsExporter) pushLogs(ctx context.Context, logs plog.L
 			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
-		resource.Attributes().PutStr(
-			solarwindsextension.EntityCreation,
-			swiExporter.config.entityCreation,
-		)
+		if !swiExporter.config.withoutEntity {
+			resource.Attributes().PutStr(
+				solarwindsextension.EntityCreation,
+				EntityCreationOnValue,
+			)
+		}
 	}
 
 	return swiExporter.logs.ConsumeLogs(ctx, logs)
@@ -285,10 +285,12 @@ func (swiExporter *solarwindsExporter) pushTraces(ctx context.Context, traces pt
 			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
-		resource.Attributes().PutStr(
-			solarwindsextension.EntityCreation,
-			swiExporter.config.entityCreation,
-		)
+		if !swiExporter.config.withoutEntity {
+			resource.Attributes().PutStr(
+				solarwindsextension.EntityCreation,
+				EntityCreationOnValue,
+			)
+		}
 	}
 
 	return swiExporter.traces.ConsumeTraces(ctx, traces)

--- a/exporter/solarwindsexporter/solarwinds_exporter.go
+++ b/exporter/solarwindsexporter/solarwinds_exporter.go
@@ -109,7 +109,13 @@ func (swiExporter *solarwindsExporter) initCommonCfgFromExtension(
 
 	// Get collector name from the extension.
 	collectorName := commonCfg.CollectorName()
+	withoutEntity := commonCfg.WithoutEntity()
 	swiExporter.config.collectorName = collectorName
+	if withoutEntity {
+		swiExporter.config.entityCreation = "off"
+	} else {
+		swiExporter.config.entityCreation = "on"
+	}
 
 	return nil
 }
@@ -237,6 +243,10 @@ func (swiExporter *solarwindsExporter) pushMetrics(ctx context.Context, metrics 
 			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
+		resource.Attributes().PutStr(
+			solarwindsextension.EntityCreation,
+			swiExporter.config.entityCreation,
+		)
 	}
 
 	return swiExporter.metrics.ConsumeMetrics(ctx, metrics)
@@ -254,6 +264,10 @@ func (swiExporter *solarwindsExporter) pushLogs(ctx context.Context, logs plog.L
 			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
 		)
+		resource.Attributes().PutStr(
+			solarwindsextension.EntityCreation,
+			swiExporter.config.entityCreation,
+		)
 	}
 
 	return swiExporter.logs.ConsumeLogs(ctx, logs)
@@ -270,6 +284,10 @@ func (swiExporter *solarwindsExporter) pushTraces(ctx context.Context, traces pt
 		resource.Attributes().PutStr(
 			solarwindsextension.CollectorNameAttribute,
 			swiExporter.config.collectorName,
+		)
+		resource.Attributes().PutStr(
+			solarwindsextension.EntityCreation,
+			swiExporter.config.entityCreation,
 		)
 	}
 

--- a/extension/solarwindsextension/common_config.go
+++ b/extension/solarwindsextension/common_config.go
@@ -46,6 +46,5 @@ func (c *commonConfig) Token() configopaque.String {
 func (c *commonConfig) CollectorName() string {
 	return c.cfg.CollectorName
 }
-func (c *commonConfig) WithoutEntity() bool {
-	return c.cfg.WithoutEntity
-}
+
+func (c *commonConfig) WithoutEntity() bool { return c.cfg.WithoutEntity }

--- a/extension/solarwindsextension/common_config.go
+++ b/extension/solarwindsextension/common_config.go
@@ -24,6 +24,7 @@ type CommonConfig interface {
 	Url() (string, error)
 	Token() configopaque.String
 	CollectorName() string
+	WithoutEntity() bool
 }
 
 type commonConfig struct{ cfg *internal.Config }
@@ -44,4 +45,7 @@ func (c *commonConfig) Token() configopaque.String {
 
 func (c *commonConfig) CollectorName() string {
 	return c.cfg.CollectorName
+}
+func (c *commonConfig) WithoutEntity() bool {
+	return c.cfg.WithoutEntity
 }

--- a/extension/solarwindsextension/extension.go
+++ b/extension/solarwindsextension/extension.go
@@ -27,6 +27,7 @@ import (
 // CollectorNameAttribute is a resource attribute
 // representing the configured name of the collector.
 const CollectorNameAttribute = internal.CollectorNameAttribute
+const EntityCreation = internal.EntityCreation
 
 type SolarwindsExtension struct {
 	logger    *zap.Logger

--- a/extension/solarwindsextension/internal/heartbeat.go
+++ b/extension/solarwindsextension/internal/heartbeat.go
@@ -31,6 +31,7 @@ import (
 const (
 	defaultHeartbeatInterval = 30 * time.Second
 	CollectorNameAttribute   = "sw.otelcol.collector.name"
+	EntityCreation           = "sw.otelcol.collector.entity_creation"
 )
 
 type MetricsExporter interface {

--- a/extension/solarwindsextension/internal/heartbeat.go
+++ b/extension/solarwindsextension/internal/heartbeat.go
@@ -168,9 +168,7 @@ func (h *Heartbeat) decorateResourceAttributes(resource pcommon.Resource) error 
 	if h.collectorName != "" {
 		resource.Attributes().PutStr(CollectorNameAttribute, h.collectorName)
 	}
-	if h.withoutEntity {
-		resource.Attributes().PutStr("sw.otelcol.collector.entity_creation", "off")
-	} else {
+	if !h.withoutEntity {
 		resource.Attributes().PutStr("sw.otelcol.collector.entity_creation", "on")
 	}
 	resource.Attributes().PutStr("sw.otelcol.collector.version", version.Version)

--- a/internal/e2e/signals_processing_test.go
+++ b/internal/e2e/signals_processing_test.go
@@ -36,7 +36,8 @@ const (
 	resourceAttributeName       = "resource.attributes.testing_attribute"
 	resourceAttributeValue      = "testing_value"
 	collectorNameAttributeName  = "sw.otelcol.collector.name"
-	collectorNameAttributeValue = "testing_collector_name"
+	collectorNameAttributeValue = "on"
+	collectorEntityCreation     = "sw.otelcol.collector.entity_creation"
 )
 
 func TestMetricStream(t *testing.T) {
@@ -213,6 +214,16 @@ func evaluateResourceAttributes(
 		val.AsString(),
 		collectorNameAttributeValue,
 		"collector name attribute value must be as configured",
+	)
+
+	// Evaluate entity_creation as an attribute.
+	val, ok = atts.Get(collectorEntityCreation)
+	require.True(t, ok, "collector entity_creation attribute must exist")
+	require.Equal(
+		t,
+		val.AsString(),
+		collectorEntityCreation,
+		"collector entity_creation attribute value must be as configured",
 	)
 }
 

--- a/internal/e2e/signals_processing_test.go
+++ b/internal/e2e/signals_processing_test.go
@@ -33,11 +33,12 @@ import (
 )
 
 const (
-	resourceAttributeName       = "resource.attributes.testing_attribute"
-	resourceAttributeValue      = "testing_value"
-	collectorNameAttributeName  = "sw.otelcol.collector.name"
-	collectorNameAttributeValue = "on"
-	collectorEntityCreation     = "sw.otelcol.collector.entity_creation"
+	resourceAttributeName                 = "resource.attributes.testing_attribute"
+	resourceAttributeValue                = "testing_value"
+	collectorNameAttributeName            = "sw.otelcol.collector.name"
+	collectorNameAttributeValue           = "testing_collector_name"
+	collectorEntityCreationAttributeName  = "sw.otelcol.collector.entity_creation"
+	collectorEntityCreationAttributeValue = "on"
 )
 
 func TestMetricStream(t *testing.T) {
@@ -216,13 +217,13 @@ func evaluateResourceAttributes(
 		"collector name attribute value must be as configured",
 	)
 
-	// Evaluate entity_creation as an attribute.
-	val, ok = atts.Get(collectorEntityCreation)
+	// Evaluate entity_creation attribute.
+	val, ok = atts.Get(collectorEntityCreationAttributeName)
 	require.True(t, ok, "collector entity_creation attribute must exist")
 	require.Equal(
 		t,
 		val.AsString(),
-		collectorEntityCreation,
+		collectorEntityCreationAttributeValue,
 		"collector entity_creation attribute value must be as configured",
 	)
 }

--- a/internal/e2e/without_entity_test.go
+++ b/internal/e2e/without_entity_test.go
@@ -37,17 +37,16 @@ func TestWithoutEntity(t *testing.T) {
 			continue
 		}
 	}
-	evaluateHeartbeatMetricHasEntityCreationAsOff(t, ms)
+	evaluateHeartbeatMetricDoesNotHaveEntityCreationAttribute(t, ms)
 }
 
-func evaluateHeartbeatMetricHasEntityCreationAsOff(
+func evaluateHeartbeatMetricDoesNotHaveEntityCreationAttribute(
 	t *testing.T,
 	ms pmetric.Metrics,
 ) {
 	require.GreaterOrEqual(t, ms.ResourceMetrics().Len(), 1, "there must be at least one metric")
 	atts := ms.ResourceMetrics().At(0).Resource().Attributes()
 
-	v, available := atts.Get("sw.otelcol.collector.entity_creation")
-	require.True(t, available, "sw.otelcol.collector.entity_creation resource attribute must be available")
-	require.Equal(t, "off", v.AsString(), "attribute value must be the same")
+	_, available := atts.Get("sw.otelcol.collector.entity_creation")
+	require.False(t, available, "sw.otelcol.collector.entity_creation resource attribute must be unavailable")
 }


### PR DESCRIPTION
Doing this to associate all outputs with entity

#### Description
Tagging all signals with entity_creation attribute.
Doing this in order for all collector outputs to be properly associated with created entity in SolarWinds Observability.

When without_entity: true is set in extension configuration, attribute is not added to any signals (and also removed from uptime heartbeat metric)

#### Testing
Manual testing against SWO
