### PR TITLE
chore: Add Windows Architecture

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -101,7 +101,7 @@ jobs:
           docker save --output solarwinds-otel-collector-windows-k8s-ltsc2022.tar solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022-k8s
           docker save --output solarwinds-otel-collector-windows-k8s-ltsc2019.tar solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2019-k8s
       
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'swo-k8s-collector')
         with:
           name: image
@@ -177,7 +177,7 @@ jobs:
       name: production
       url: https://hub.docker.com/repository/docker/solarwinds/solarwinds-otel-collector
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: image
 

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -54,7 +54,10 @@ jobs:
 
   build_and_test_windows:
     runs-on: windows-2022
-    #if: startsWith(github.ref, 'refs/tags/')
+    # this job takes a long time to run (30-40 minutes), so run it on release and 
+    # run it on main and release branches to have some continuous check that build on windows 
+    # still works. Also run it on workflow_dispatch to allow manual runs.
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.event_name == 'workflow_dispatch'
     outputs:
       image_tag: ${{ steps.generate-tag.outputs.value }}
     steps:

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -52,6 +52,63 @@ jobs:
         working-directory: internal/e2e
         run: make e2e-tests
 
+  build_and_test_windows:
+    runs-on: windows-2022
+    #if: startsWith(github.ref, 'refs/tags/')
+    outputs:
+      image_tag: ${{ steps.generate-tag.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate docker image tag
+        id: generate-tag
+        run: echo "::set-output name=value::v${{ github.run_number }}-$(git rev-parse --short HEAD)"
+
+      - name: Build Full
+        run: |
+          docker build -t solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022 -f build/docker/Dockerfile.Windows-2022 . 
+          
+      - name: Build K8s
+        run: |
+          docker build -t solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022-k8s -f build/docker/Dockerfile.k8s.Windows-2022 . 
+          
+      - name: CP assets
+        run: |
+          docker create --name assets solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022
+          docker cp assets:/solarwinds-otel-collector.exe solarwinds-otel-collector.exe
+          docker create --name assets-k8s solarwinds-otel-collector:k8s-${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022
+          docker cp assets-k8s:/solarwinds-otel-collector.exe solarwinds-otel-collector-k8s.exe
+          docker cp assets-k8s:/wrapper.exe wrapper.exe
+
+      - name: Build 2019 Full
+        run: |
+          docker build -t solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2019 --build-arg WINBASE=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f build/docker/Dockerfile.Windows-Runtime . 
+
+      - name: Build 2019 K8s
+        run: |
+          Move-Item -Path solarwinds-otel-collector-k8s.exe -Destination solarwinds-otel-collector.exe -Force
+          docker build -t solarwinds-otel-collector:k8s-${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2019 --build-arg WINBASE=mcr.microsoft.com/windows/nanoserver:ltsc2019 -f build/docker/Dockerfile.k8s.Windows-Runtime . 
+            
+      - name: Save image
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'swo-k8s-collector')
+        run: |
+          docker save --output solarwinds-otel-collector-windows-ltsc2022.tar solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022
+          docker save --output solarwinds-otel-collector-windows-ltsc2019.tar solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2019
+          docker save --output solarwinds-otel-collector-windows-k8s-ltsc2022.tar solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022-k8s
+          docker save --output solarwinds-otel-collector-windows-k8s-ltsc2019.tar solarwinds-otel-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2019-k8s
+      
+      - uses: actions/upload-artifact@v3
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'swo-k8s-collector')
+        with:
+          name: image
+          path: |
+            solarwinds-otel-collector-windows-ltsc2022.tar
+            solarwinds-otel-collector-windows-ltsc2019.tar
+            solarwinds-otel-collector-windows-k8s-ltsc2022.tar
+            solarwinds-otel-collector-windows-k8s-ltsc2019.tar
+          retention-days: 2
+ 
   build_k8s:
     runs-on: ubuntu-latest
     outputs:
@@ -68,7 +125,6 @@ jobs:
         run: >
           docker build . --file build/docker/Dockerfile.k8s
           --tag solarwinds-otel-collector:${{ steps.generate-tag.outputs.tag }}-k8s
-
 
   deploy_dockerhub:
     runs-on: ubuntu-latest
@@ -109,10 +165,55 @@ jobs:
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}
             ${{ env.DOCKERHUB_IMAGE }}:latest
 
+  deploy_dockerhub_windows:
+    runs-on: windows-2022
+    needs: build_and_test_windows
+    name: Deploy to docker hub Windows
+    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: production
+      url: https://hub.docker.com/repository/docker/solarwinds/solarwinds-otel-collector
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: image
+
+      - name: Get image tag
+        id: vars
+        run: echo "tag=$env:GITHUB_REF_NAME" >> $ENV:GITHUB_OUTPUT
+
+      - name: Load image
+        run: |
+          docker load --input solarwinds-otel-collector-windows-ltsc2022.tar
+          docker load --input solarwinds-otel-collector-windows-ltsc2019.tar
+          docker load --input solarwinds-otel-collector-windows-k8s-ltsc2022.tar
+          docker load --input solarwinds-otel-collector-windows-k8s-ltsc2019.tar
+
+      - name: Tag images
+        run: |
+          docker tag solarwinds-otel-collector:${{ needs.build_and_test_windows.outputs.image_tag }}-nanoserver-ltsc2022 ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022
+          docker tag solarwinds-otel-collector:${{ needs.build_and_test_windows.outputs.image_tag }}-nanoserver-ltsc2019 ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019
+          docker tag solarwinds-otel-collector:${{ needs.build_and_test_windows.outputs.image_tag }}-nanoserver-ltsc2022-k8s ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022-k8s
+          docker tag solarwinds-otel-collector:${{ needs.build_and_test_windows.outputs.image_tag }}-nanoserver-ltsc2019-k8s ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019-k8s
+
+      - name: Docker login
+        env:
+          OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD }}
+          OPENTELEMETRY_DOCKER_HUB_CI_USER: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_USER }}
+        run: echo "$env:OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD" | docker login -u "$env:OPENTELEMETRY_DOCKER_HUB_CI_USER" --password-stdin
+
+      - name: Push as specific
+        run: | 
+          docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022
+          docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019
+          docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022-k8s
+          docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019-k8s
+
   create_and_push_docker_manifest:
     runs-on: ubuntu-latest
     needs:
       - deploy_dockerhub
+      - deploy_dockerhub_windows
     name: Create Multi-platform Docker Manifest
     steps:
       - name: Checkout
@@ -135,12 +236,30 @@ jobs:
       - name: Create Multi-arch Manifest for Full Image
         run: |
           docker manifest create ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}  \
+            --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-nanoserver-ltsc2022 \
+            --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-nanoserver-ltsc2019 \
             --amend ${{ env.DOCKERHUB_IMAGE }}@$(jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' manifest-full.json) \
             --amend ${{ env.DOCKERHUB_IMAGE }}@$(jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' manifest-full.json)
 
-      - name: Push multi-arch manifest
+      - name: Get Manifest for K8s Image
+        run: |
+          docker manifest inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-k8s > manifest-k8s.json
+          
+      - name: Create Multi-arch Manifest for K8s Image
+        run: |
+          docker manifest create ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-k8s  \
+            --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-nanoserver-ltsc2022-k8s \
+            --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-nanoserver-ltsc2019-k8s \
+            --amend ${{ env.DOCKERHUB_IMAGE }}@$(jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' manifest-full.json) \
+            --amend ${{ env.DOCKERHUB_IMAGE }}@$(jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' manifest-full.json)
+
+      - name: Push multi-arch full manifest
         run: |
           docker manifest push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}
+
+      - name: Push multi-arch k8s manifest
+        run: |
+          docker manifest push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }}-k8s
 
   create_release:
     runs-on: ubuntu-latest

--- a/build/docker/Dockerfile.Windows-2022
+++ b/build/docker/Dockerfile.Windows-2022
@@ -1,0 +1,20 @@
+FROM docker.io/library/golang:1.23.4-nanoserver-ltsc2022@sha256:3339084b38f4052b815c7a1a32740796ed5cccb41119268938d2a6b57cc726c9 AS base
+
+COPY ./ /src
+WORKDIR /src
+
+FROM base AS builder
+
+ARG CGO_ENABLED=0
+ARG GOEXPERIMENT=boringcrypto
+
+RUN cd /src/cmd/solarwinds-otel-collector && go build -tags full -trimpath -o /src/bin/solarwinds-otel-collector "-ldflags=-s -w"
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+COPY --from=builder /src/bin/solarwinds-otel-collector /solarwinds-otel-collector.exe
+
+ENTRYPOINT ["solarwinds-otel-collector.exe"]
+CMD ["--config=/opt/default-config.yaml"]
+
+

--- a/build/docker/Dockerfile.Windows-Runtime
+++ b/build/docker/Dockerfile.Windows-Runtime
@@ -1,0 +1,8 @@
+ARG WINBASE
+
+FROM ${WINBASE}
+
+COPY /solarwinds-otel-collector.exe /solarwinds-otel-collector.exe
+
+ENTRYPOINT ["solarwinds-otel-collector.exe"]
+CMD ["--config=/opt/default-config.yaml"]

--- a/build/docker/Dockerfile.k8s.Windows-2022
+++ b/build/docker/Dockerfile.k8s.Windows-2022
@@ -1,0 +1,29 @@
+FROM docker.io/library/golang:1.23.4-nanoserver-ltsc2022@sha256:3339084b38f4052b815c7a1a32740796ed5cccb41119268938d2a6b57cc726c9 AS base
+
+COPY ./ /src
+WORKDIR /src
+
+FROM base AS builder
+
+ARG CGO_ENABLED=0
+ARG GOEXPERIMENT=boringcrypto
+
+RUN cd /src/cmd/solarwinds-otel-collector && go build -tags k8s -trimpath -o /src/bin/solarwinds-otel-collector "-ldflags=-s -w"
+
+FROM base AS wrapper
+WORKDIR /src/cmd/wrapper
+
+ARG CGO_ENABLED=0
+ARG GOEXPERIMENT=boringcrypto
+
+RUN go build -a -o /src/bin/wrapper.exe
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+COPY --from=builder /src/bin/solarwinds-otel-collector /solarwinds-otel-collector.exe
+COPY --from=wrapper /src/bin/wrapper.exe /wrapper.exe
+
+ENTRYPOINT ["wrapper.exe"]
+CMD ["solarwinds-otel-collector.exe", "--config=/opt/default-config.yaml"]
+
+

--- a/build/docker/Dockerfile.k8s.Windows-Runtime
+++ b/build/docker/Dockerfile.k8s.Windows-Runtime
@@ -1,0 +1,9 @@
+ARG WINBASE
+
+FROM ${WINBASE}
+
+COPY /solarwinds-otel-collector.exe /solarwinds-otel-collector.exe
+COPY /wrapper.exe /wrapper.exe
+
+ENTRYPOINT ["wrapper.exe"]
+CMD ["solarwinds-otel-collector.exe", "--config=/opt/default-config.yaml"]

--- a/cmd/solarwinds-otel-collector/main.go
+++ b/cmd/solarwinds-otel-collector/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 }
 
-func run(params otelcol.CollectorSettings) error {
+func runInteractive(params otelcol.CollectorSettings) error {
 	cmd := otelcol.NewCommand(params)
 	err := cmd.Execute()
 	return err

--- a/cmd/solarwinds-otel-collector/main_others.go
+++ b/cmd/solarwinds-otel-collector/main_others.go
@@ -1,0 +1,23 @@
+// Copyright 2025 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import "go.opentelemetry.io/collector/otelcol"
+
+func run(params otelcol.CollectorSettings) error {
+	return runInteractive(params)
+}

--- a/cmd/solarwinds-otel-collector/main_windows.go
+++ b/cmd/solarwinds-otel-collector/main_windows.go
@@ -1,0 +1,42 @@
+// Copyright 2025 SolarWinds Worldwide, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/otelcol"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+func run(params otelcol.CollectorSettings) error {
+	// No need to supply service name when startup is invoked through
+	// the Service Control Manager directly.
+	if err := svc.Run("", otelcol.NewSvcHandler(params)); err != nil {
+		if errors.Is(err, windows.ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
+			// Per https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-startservicectrldispatchera#return-value
+			// this means that the process is not running as a service, so run interactively.
+			return runInteractive(params)
+		}
+
+		return fmt.Errorf("failed to start collector server: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
* Adding windows build to the pipeline and to the multiarch
* Add possibility to run collector as windows service
* Since windows build takes a long time to run (30-40 minutes), so run it only on main and release branches to have some continuous check that build on windows still works. 
* Windows architectures are being added to multi-arch manifest
* I enabled run also on manual runs, here is manual run I triggered for this job to show that windows build is fine: https://github.com/solarwinds/solarwinds-otel-collector/actions/runs/13054997673
* NOTE: I couldn't test if the publishing part works
* This is prerequisite for: https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/879