### PR TITLE
fix: Adding missing batch processor in k8s image distribution

### DIFF
--- a/cmd/solarwinds-otel-collector/components_k8s.go
+++ b/cmd/solarwinds-otel-collector/components_k8s.go
@@ -53,6 +53,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 
 	"go.opentelemetry.io/collector/exporter"
@@ -107,6 +108,7 @@ func components() (otelcol.Factories, error) {
 		resourceprocessor.NewFactory(),
 		transformprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
+		batchprocessor.NewFactory(),
 	)
 
 	if err != nil {


### PR DESCRIPTION
prerequisity for https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/879