### PR TITLE
chore: Update Go to 1.23.5 and release new image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## vNext
 
 ## v0.113.8
-Updates Go build toolchain to 1.23.5.
+- Updates Go build toolchain to 1.23.5.
+- Adds [SWO Host Metrics Receiver](./receiver/swohostmetricsreceiver/README.md) for additional Host metrics monitoring.
+- Adds connection check functionality to K8s distribution startup.
+- Adds Windows architecture for Docker builds.
 
 ## v0.113.7
 - adding `without_entity` to [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started) configuration, so users can opt out of collector entity creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## vNext
+
+## v0.113.8
 Updates Go build toolchain to 1.23.5.
 
 ## v0.113.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+Updates Go build toolchain to 1.23.5.
 
 ## v0.113.7
 - adding `without_entity` to [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started) configuration, so users can opt out of collector entity creation.

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.4-bookworm AS base
+FROM docker.io/library/golang:1.23.5-bookworm AS base
 
 COPY /LICENSE /LICENSE
 COPY ./ /src

--- a/build/docker/Dockerfile.Windows-2022
+++ b/build/docker/Dockerfile.Windows-2022
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.4-nanoserver-ltsc2022@sha256:3339084b38f4052b815c7a1a32740796ed5cccb41119268938d2a6b57cc726c9 AS base
+FROM docker.io/library/golang:1.23.5-nanoserver-ltsc2022@sha256:afdf65b8a9678307898c8762e31ab2ceb3ec023761544cdee4e9dcf368282acf AS base
 
 COPY ./ /src
 WORKDIR /src

--- a/build/docker/Dockerfile.k8s
+++ b/build/docker/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.4-bookworm AS base
+FROM docker.io/library/golang:1.23.5-bookworm AS base
 
 COPY /LICENSE /LICENSE
 COPY ./ /src

--- a/build/docker/Dockerfile.k8s.Windows-2022
+++ b/build/docker/Dockerfile.k8s.Windows-2022
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.4-nanoserver-ltsc2022@sha256:3339084b38f4052b815c7a1a32740796ed5cccb41119268938d2a6b57cc726c9 AS base
+FROM docker.io/library/golang:1.23.5-nanoserver-ltsc2022@sha256:afdf65b8a9678307898c8762e31ab2ceb3ec023761544cdee4e9dcf368282acf AS base
 
 COPY ./ /src
 WORKDIR /src

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,10 +161,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.113.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.113.0
-	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.113.7
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.113.7
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.7
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.113.7
+	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.113.8
 	github.com/spf13/cobra v1.8.1
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/confmap v1.21.0
@@ -581,7 +581,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.7 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexport
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.113.7
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.7
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/config/configgrpc v0.113.0
@@ -40,7 +40,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.7 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8 // indirect
 	go.opentelemetry.io/collector/client v1.19.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.113.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.20.0 // indirect

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsexten
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.7
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/config/configgrpc v0.113.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/mdelapenya/tlscert v0.1.0
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.34.0
 	go.opentelemetry.io/collector/pdata v1.19.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.113.7"
+const Version = "0.113.8"

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.7
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v0.113.0


### PR DESCRIPTION
#### Description
Updates Go build toolchain to 1.23.5 and releases a new image 0.113.8.
