### PR TITLE
chore: prepare release 0.119.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+## v0.119.0
+- Consumes OpenTelemetry Collector dependencies v0.119.0.
+
 ## v0.113.8
 - Updates Go build toolchain to 1.23.5.
 - Adds [SWO Host Metrics Receiver](./receiver/swohostmetricsreceiver/README.md) for additional Host metrics monitoring.
@@ -9,14 +12,14 @@
 - Adds Windows architecture for Docker builds.
 
 ## v0.113.7
-- adding `without_entity` to [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started) configuration, so users can opt out of collector entity creation.
-- tagging all signals with `entity_creation` attribute, except when without_entity is set on [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started).
+- Adds `without_entity` to [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started) configuration, so users can opt out of collector entity creation.
+- Tags all signals with `entity_creation` attribute, except when without_entity is set on [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started).
 
 ## v0.113.6
-- Mark all outgoing telemetry from the [SolarWinds Exporter](./exporter/solarwindsexporter) with
+- Marks all outgoing telemetry from the [SolarWinds Exporter](./exporter/solarwindsexporter) with
 an attribute storing the collector name (`sw.otelcol.collector.name`) as it is configured in the
 [SolarWinds Extension](./extension/solarwindsextension/README.md#getting-started).
-- The uptime metric used to signal heartbeat is now decorated with `sw.otelcol.collector.version` which contains collector version
+- The uptime metric used to signal heartbeat is now decorated with `sw.otelcol.collector.version` which contains collector version.
 
 ## v0.113.5
 Tags released docker images with `latest` tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## vNext
 
-## v0.119.0
-
 ## v0.113.8
 - Updates Go build toolchain to 1.23.5.
 - Adds [SWO Host Metrics Receiver](./receiver/swohostmetricsreceiver/README.md) for additional Host metrics monitoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.119.0
+
 ## v0.113.8
 - Updates Go build toolchain to 1.23.5.
 - Adds [SWO Host Metrics Receiver](./receiver/swohostmetricsreceiver/README.md) for additional Host metrics monitoring.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To run the image utilize following command:
 See [complete docker documentation](./build/docker/README.md).
 
 ### Binary
-Build the binary in `cmd/solarwinds-otel-collector` with `go build .`
+Build the binary in `cmd/solarwinds-otel-collector` with `go build -tags full .`
 
 After successful build, `solarwinds-otel-collector` should be present in `cmd/solarwinds-otel-collector`.
 

--- a/build/prepare-release.sh
+++ b/build/prepare-release.sh
@@ -27,7 +27,7 @@ if [ ! -f "$CHANGELOG_FILE" ]; then
     exit 1
 fi
 if ! grep -q "## v$VERSION" "$CHANGELOG_FILE"; then
-    sed -E -i "" "s/^## vNext/## vNext\n\n## v$VERSION/" "$CHANGELOG_FILE"
+    perl -pi -e "s/^## vNext/## vNext\n\n## v$VERSION/" "$CHANGELOG_FILE"
     echo "CHANGELOG.md updated with version v$VERSION"
 else
     echo "CHANGELOG.md already contains 'v$VERSION', no update made."
@@ -36,7 +36,7 @@ fi
 # Update go.mod files
 ALL_GO_MOD=$(find . -name "go.mod" -type f | sort)
 for f in $ALL_GO_MOD; do
-    sed -i -E "s|^(\s+github.com/solarwinds/solarwinds-otel-collector/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+(\s+// indirect)?$|\1 v$VERSION\2|" "$f"
+    perl -pi -e "s|^(\s+github.com/solarwinds/solarwinds-otel-collector/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+(\s+// indirect)?$|\1 v$VERSION\2|" "$f"
     echo "References to 'github.com/solarwinds/solarwinds-otel-collector' in $f updated with version v$VERSION"
 done
 
@@ -46,5 +46,5 @@ if [ ! -f "$GO_VERSION_FILE" ]; then
     echo "version.go not found!"
     exit 1
 fi
-sed -E -i "" "s|^(const Version =) \"[0-9]+\.[0-9]+\.[0-9]+\"$|\1 \"$VERSION\"|" "$GO_VERSION_FILE"
+perl -pi -e "s|^(const Version =) \"[0-9]+\.[0-9]+\.[0-9]+\"$|\1 \"$VERSION\"|" "$GO_VERSION_FILE"
 echo "Version.go updated with version $VERSION"

--- a/build/prepare-release.sh
+++ b/build/prepare-release.sh
@@ -27,7 +27,7 @@ if [ ! -f "$CHANGELOG_FILE" ]; then
     exit 1
 fi
 if ! grep -q "## v$VERSION" "$CHANGELOG_FILE"; then
-    sed -i -E "s/^## vNext/## vNext\n\n## v$VERSION/" "$CHANGELOG_FILE"
+    sed -E -i "" "s/^## vNext/## vNext\n\n## v$VERSION/" "$CHANGELOG_FILE"
     echo "CHANGELOG.md updated with version v$VERSION"
 else
     echo "CHANGELOG.md already contains 'v$VERSION', no update made."
@@ -46,5 +46,5 @@ if [ ! -f "$GO_VERSION_FILE" ]; then
     echo "version.go not found!"
     exit 1
 fi
-sed -i -E "s|^(const Version =) \"[0-9]+\.[0-9]+\.[0-9]+\"$|\1 \"$VERSION\"|" "$GO_VERSION_FILE"
+sed -E -i "" "s|^(const Version =) \"[0-9]+\.[0-9]+\.[0-9]+\"$|\1 \"$VERSION\"|" "$GO_VERSION_FILE"
 echo "Version.go updated with version $VERSION"

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,10 +161,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.113.8
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.113.8
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.0
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.0
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.0
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.0
 	github.com/spf13/cobra v1.8.1
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/confmap v1.25.0
@@ -585,7 +585,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.0 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexport
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.113.8
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.0
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0
@@ -42,7 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsexten
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.0
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/mdelapenya/tlscert v0.1.0
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	go.opentelemetry.io/collector/pdata v1.25.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.113.8"
+const Version = "0.119.0"

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.113.8
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.113.8
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.0
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.0
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v0.119.0


### PR DESCRIPTION
#### Description
Bumps the version to 0.119.0. Few additions made along the way:
- build: utilized `perl` instead of `sed` to guarantee same behavior across platforms (`sed` behaved differently with undesired results for MacOS)
- docs: adjusted CHANGELOG.md messages to follow same pattern that can be continued
- docs: fixed incorrect build command in README.md. Running sole `go build` without tags results in build failure.


#### Testing
Initiated GHA runs with uncomitted changes to validate the version update checks still work after migrating to `perl`