### PR TITLE
chore: #56 Inherit secrets in build and test workflow

### DIFF
--- a/.github/actions/dockerScoutScan/action.yml
+++ b/.github/actions/dockerScoutScan/action.yml
@@ -8,9 +8,6 @@ inputs:
   token:
     description: PAT token for logging into the Docker Scout
     required: true
-  github-token:
-    description: GitHub token for commenting the PR
-    required: true
   current-image:
     description: Image to be compared
     required: true

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Docker scout image scan
         uses: ./.github/actions/dockerScoutScan
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           token: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
           current-image: solarwinds-otel-collector
@@ -99,7 +98,6 @@ jobs:
       - name: Docker scout image scan for Windows 2019
         uses: ./.github/actions/dockerScoutScan
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           token: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
           current-image: solarwinds-otel-collector
@@ -110,7 +108,6 @@ jobs:
       - name: Docker scout image scan for Windows 2022
         uses: ./.github/actions/dockerScoutScan
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           token: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
           current-image: solarwinds-otel-collector
@@ -146,7 +143,6 @@ jobs:
       - name: Docker scout image scan
         uses: ./.github/actions/dockerScoutScan
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           token: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
           current-image: solarwinds-otel-collector
@@ -183,7 +179,6 @@ jobs:
       - name: Docker scout image scan for Windows 2019
         uses: ./.github/actions/dockerScoutScan
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           token: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
           current-image: solarwinds-otel-collector
@@ -194,7 +189,6 @@ jobs:
       - name: Docker scout image scan for Windows 2022
         uses: ./.github/actions/dockerScoutScan
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ vars.ENOPS5919_DOCKER_SCOUT_CI_USER }}
           token: ${{ secrets.ENOPS5919_DOCKER_SCOUT_CI_PAT }}
           current-image: solarwinds-otel-collector

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
   build_and_test:
     name: Build and Test images
     uses: ./.github/workflows/buildAndTest.yml
+    secrets: inherit
 
   deploy_dockerhub:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Description
When calling workflow from another, the callee is missing secret. It seems the secret has to be explicitly passed - `inherit` should pass all secrets to the callee workflow.

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector/issues/56

#### Testing
No test cases added -> github configuration.
