### PR TITLE
chore: #56 Fix artifact paths to sarif files

### DIFF
--- a/.github/actions/analyzeCves/action.yml
+++ b/.github/actions/analyzeCves/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: docker/scout-action@v1
       with:
         command: cves
-        image: solarwinds-otel-collector:${{ inputs.tag }}
+        image: ${{ env.DOCKERHUB_IMAGE }}:${{ inputs.tag }}
         sarif-file: sarif-${{ inputs.tag }}.output.json
         summary: true
 

--- a/.github/actions/analyzeCves/action.yml
+++ b/.github/actions/analyzeCves/action.yml
@@ -14,11 +14,9 @@ runs:
       uses: docker/scout-action@v1
       with:
         command: cves
-        only-severities: critical,high
         image: solarwinds-otel-collector:${{ inputs.tag }}
         sarif-file: sarif-${{ inputs.tag }}.output.json
         summary: true
-        exit-code: true
 
     - name: Save sarif file as an artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,22 +142,22 @@ jobs:
       - name: Analyze cves Windows 2022
         uses: ./.github/actions/analyzeCves
         with:
-          tag: ${{ steps.generate-tag.outputs.tag }}-nanoserver-ltsc2022
+          tag: ${{ needs.release_checks.outputs.image_tag }}-nanoserver-ltsc2022
 
       - name: Analyze cves Windows 2019
         uses: ./.github/actions/analyzeCves
         with:
-          tag: ${{ steps.generate-tag.outputs.tag }}-nanoserver-ltsc2019
+          tag: ${{ needs.release_checks.outputs.image_tag }}-nanoserver-ltsc2019
 
       - name: Analyze cves Windows 2022 k8s
         uses: ./.github/actions/analyzeCves
         with:
-          tag: ${{ steps.generate-tag.outputs.tag }}-nanoserver-ltsc2022-k8s
+          tag: ${{ needs.release_checks.outputs.image_tag }}-nanoserver-ltsc2022-k8s
 
       - name: Analyze cves Windows 2019 k8s
         uses: ./.github/actions/analyzeCves
         with:
-          tag: ${{ steps.generate-tag.outputs.tag }}-nanoserver-ltsc2019-k8s
+          tag: ${{ needs.release_checks.outputs.image_tag }}-nanoserver-ltsc2019-k8s
 
       - name: Login to Docker to use Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/uploadSarifFiles.yml
+++ b/.github/workflows/uploadSarifFiles.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Generate Docker Image Tag
         id: generate-tag
-        run: echo "tag=v${{ github.run_number }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "tag=$(grep -oP '(?<=const Version = ")[^"]+' "./pkg/version/version.go")" >> $GITHUB_OUTPUT
 
   upload_sarif_files:
     runs-on: ubuntu-latest
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         tag:
-          - ${{ needs.generate-tag.outputs.tag }}-nanoserver-ltsc2019
           - ${{ needs.generate-tag.outputs.tag }}-nanoserver-ltsc2022
-          - ${{ needs.generate-tag.outputs.tag }}-nanoserver-ltsc2019-k8s
+          - ${{ needs.generate-tag.outputs.tag }}-nanoserver-ltsc2019
           - ${{ needs.generate-tag.outputs.tag }}-nanoserver-ltsc2022-k8s
+          - ${{ needs.generate-tag.outputs.tag }}-nanoserver-ltsc2019-k8s
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
#### Description
Currently github.run_number which increments with each run of that workflow. For example run_number for upload sarif was `v4` but for deploy images it was `v10`.

I didn't want to change this specific tag since it would trigger changes in `build_and_test` workflow when saving windows images.

The solution is to use other tag `<release_version>-nanoserver-*` where release version can be easily parsed from `version.go` and should be equal in "deploy" and "upload sarif" workflows.

I would leave at least some sort of version metadata for each sarif file, so it is easy to identify which run the sarif output belongs to.

💡 Additionally, I am omitting exit-code and filter for cves as now it does not have any added value since the file is always empty :) We can take care of failing on `critical/high` vulnerability in follow-up.

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector/issues/56

#### Testing
No test cases.
