### PR TITLE
chore: #56 Revert changes in exit codes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           if ! gh release view "v${{ steps.get-tag.outputs.tag }}" 2>&1 | grep -q "^release not found$"; then
             echo "Release v${{ steps.get-tag.outputs.tag }} already exists on GitHub."
+            exit 1
           fi
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -42,6 +43,7 @@ jobs:
         run: |
           if ! docker manifest inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }} 2>&1 | grep -q "no such manifest"; then
             echo "Docker image ${{ env.DOCKERHUB_IMAGE }}:${{ steps.get-tag.outputs.tag }} already exists on DockerHub."
+            exit 1
           fi
 
   build_and_test:


### PR DESCRIPTION
#### Description
Return exit codes to deploy workflow. Two exit codes were ignored so we were able to override existing images in the DockerHub with the same tag.

**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector/issues/56

The change was for example introduced here: https://github.com/solarwinds/solarwinds-otel-collector/pull/68/files

#### Testing
No test cases.
