### PR TITLE
chore: #96 updating swok8sobjectsreceiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+## v0.119.4
+- Updating `swok8sobjectsreceiver` to report changes in other than `status`, `spec`, and `metadata` sections
+
 ## v0.119.3
 - Adds custom `k8sobjectsreceiver` to notify about what sections in manifest were changed 
 

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,12 +161,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver v0.119.3
+	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver v0.119.4
 	github.com/spf13/cobra v1.8.1
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/confmap v1.26.0
@@ -587,8 +587,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.3 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.3 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.4 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexport
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.3
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0
@@ -42,7 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.3 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsexten
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.3
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 require (
 	github.com/mdelapenya/tlscert v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.3
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	go.opentelemetry.io/collector/pdata v1.25.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.119.3"
+const Version = "0.119.4"

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.3
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.3
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v0.119.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.3
+	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.4
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/receiver/swok8sobjectsreceiver/receiver.go
+++ b/receiver/swok8sobjectsreceiver/receiver.go
@@ -69,6 +69,7 @@ type objecthashes struct {
 	Metadata string `json:"metadata"`
 	Spec     string `json:"spec"`
 	Status   string `json:"status"`
+	Other    string `json:"other"`
 }
 
 func newReceiver(params receiver.Settings, config *Config, consumer consumer.Logs) (receiver.Logs, error) {
@@ -304,6 +305,7 @@ func (kr *k8sobjectsreceiver) watchEventToLogData(ctx context.Context, event *ap
 	statusChanged := true
 	metadataChanged := true
 	specChanged := true
+	otherChanged := true
 
 	storage.mu.Lock()
 	oldHashes, exists := storage.Objects[key]
@@ -311,6 +313,7 @@ func (kr *k8sobjectsreceiver) watchEventToLogData(ctx context.Context, event *ap
 		metadataChanged = oldHashes.Metadata != hashes.Metadata
 		specChanged = oldHashes.Spec != hashes.Spec
 		statusChanged = oldHashes.Status != hashes.Status
+		otherChanged = oldHashes.Other != hashes.Other
 	}
 	storage.Objects[key] = *hashes
 
@@ -319,7 +322,7 @@ func (kr *k8sobjectsreceiver) watchEventToLogData(ctx context.Context, event *ap
 	}
 	storage.mu.Unlock()
 
-	if !metadataChanged && !statusChanged && !specChanged {
+	if !metadataChanged && !statusChanged && !specChanged && !otherChanged {
 		return nil
 	}
 
@@ -328,6 +331,7 @@ func (kr *k8sobjectsreceiver) watchEventToLogData(ctx context.Context, event *ap
 		attrs.PutBool("sw.metadata.changed", metadataChanged)
 		attrs.PutBool("sw.status.changed", statusChanged)
 		attrs.PutBool("sw.spec.changed", specChanged)
+		attrs.PutBool("sw.other.changed", otherChanged)
 	})
 	if err != nil {
 		return fmt.Errorf("error converting watch objects to log data %w", err)
@@ -384,15 +388,27 @@ func (kr *k8sobjectsreceiver) loadStorage(ctx context.Context, storage *objectst
 }
 
 func getObjectHashes(udata *unstructured.Unstructured) (*objecthashes, error) {
-	metadataHash, err := getHash(udata, "metadata")
+	udataCopy := udata.DeepCopy()
+	udataCopy.SetResourceVersion("") // do not report changes in resource version
+	udataCopy.SetManagedFields(nil)  // do not report changes in managed fields
+
+	metadataHash, err := getHash(udataCopy, "metadata")
 	if err != nil {
 		return nil, err
 	}
-	specHash, err := getHash(udata, "spec")
+	specHash, err := getHash(udataCopy, "spec")
 	if err != nil {
 		return nil, err
 	}
-	statusHash, err := getHash(udata, "status")
+	statusHash, err := getHash(udataCopy, "status")
+	if err != nil {
+		return nil, err
+	}
+
+	unstructured.RemoveNestedField(udataCopy.Object, "metadata")
+	unstructured.RemoveNestedField(udataCopy.Object, "spec")
+	unstructured.RemoveNestedField(udataCopy.Object, "status")
+	otherHash, err := getHash(udataCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -401,10 +417,21 @@ func getObjectHashes(udata *unstructured.Unstructured) (*objecthashes, error) {
 		Metadata: metadataHash,
 		Spec:     specHash,
 		Status:   statusHash,
+		Other:    otherHash,
 	}, nil
 }
 
+// returns hash of a nested fields or whole object if no fields are provided
 func getHash(udata *unstructured.Unstructured, fields ...string) (string, error) {
+	if len(fields) == 0 {
+		bytes, err := udata.MarshalJSON()
+		if err != nil {
+			return "", err
+		}
+
+		return fmt.Sprintf("%x", sha256.Sum256(bytes)), nil
+	}
+
 	nested, found, err := unstructured.NestedFieldCopy(udata.Object, fields...)
 	if err != nil {
 		return "", err

--- a/receiver/swok8sobjectsreceiver/receiver.go
+++ b/receiver/swok8sobjectsreceiver/receiver.go
@@ -296,6 +296,9 @@ func (kr *k8sobjectsreceiver) watchEventToLogData(ctx context.Context, event *ap
 		return fmt.Errorf("received data that wasnt unstructure, %v", event)
 	}
 
+	// clear out managed fields
+	udata.SetManagedFields(nil)
+
 	key := getKey(udata)
 	hashes, err := getObjectHashes(udata)
 	if err != nil {
@@ -390,7 +393,6 @@ func (kr *k8sobjectsreceiver) loadStorage(ctx context.Context, storage *objectst
 func getObjectHashes(udata *unstructured.Unstructured) (*objecthashes, error) {
 	udataCopy := udata.DeepCopy()
 	udataCopy.SetResourceVersion("") // do not report changes in resource version
-	udataCopy.SetManagedFields(nil)  // do not report changes in managed fields
 
 	metadataHash, err := getHash(udataCopy, "metadata")
 	if err != nil {


### PR DESCRIPTION
#### Description
Update `swok8sobjectsreceiver` to send changes in other than `status`, `spec` and `metadata` sections. 
Do not report changes in `resourceVersion`. Remove `managedFileds` from manifests.
Release 0.119.4

<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector/issues/96
-->

#### Testing
Manual check with swi-k8s-opentelemetry-collector on docker-desktop
