### PR TITLE
chore: #96 swok8sobjectsreceiver remove managed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+## v0.119.5
+- Updating `swok8sobjectsreceiver` to remove `managedFields` for both PULL and WATCH objects
+
 ## v0.119.4
 - Updating `swok8sobjectsreceiver` to report changes in other than `status`, `spec`, and `metadata` sections
 

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,12 +161,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver v0.119.5
 	github.com/spf13/cobra v1.8.1
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/confmap v1.26.0
@@ -587,8 +587,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.4 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.5 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.5 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexport
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.5
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0
@@ -42,7 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsexten
 go 1.23.4
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.5
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 require (
 	github.com/mdelapenya/tlscert v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.5
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	go.opentelemetry.io/collector/pdata v1.25.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.119.4"
+const Version = "0.119.5"

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.4
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.5
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.5
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v0.119.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.4
+	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.5
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/receiver/swok8sobjectsreceiver/receiver.go
+++ b/receiver/swok8sobjectsreceiver/receiver.go
@@ -191,6 +191,10 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 			if err != nil {
 				kr.setting.Logger.Error("error in pulling object", zap.String("resource", config.gvr.String()), zap.Error(err))
 			} else if len(objects.Items) > 0 {
+				// clear out managed fields
+				for _, item := range objects.Items {
+					item.SetManagedFields(nil)
+				}
 				logs := pullObjectsToLogData(objects, time.Now(), config)
 				obsCtx := kr.obsrecv.StartLogsOp(ctx)
 				logRecordCount := logs.LogRecordCount()


### PR DESCRIPTION
#### Description
Updating swok8sobjectsreceover to remove managedFields from PULLed objects as well.
Increasing image version to 0.119.5

<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector/issues/96
-->

#### Testing
Manual test
