### PR TITLE
chore: Fix CVE-2025-22866, prepare release 0.119.7

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -154,7 +154,7 @@ jobs:
     runs-on: windows-2022
     # this job takes a long time to run (10 minutes), so run it on main and release branches to have some continuous check that build on windows
     # still works. Also run it on workflow_dispatch to allow manual runs.
-    if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    # if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     needs: generate_tag
     steps:
       - name: Checkout
@@ -210,7 +210,7 @@ jobs:
 
   write_docker_scout_info_comment:
     runs-on: ubuntu-latest
-    needs: ['build_and_test', 'build_k8s']
+    needs: ['build_and_test', 'build_k8s', 'build_windows_k8s']
     if: |
       !contains(needs.*.result, 'failure') &&
       github.event_name == 'pull_request'

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -154,7 +154,7 @@ jobs:
     runs-on: windows-2022
     # this job takes a long time to run (10 minutes), so run it on main and release branches to have some continuous check that build on windows
     # still works. Also run it on workflow_dispatch to allow manual runs.
-    # if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     needs: generate_tag
     steps:
       - name: Checkout
@@ -210,7 +210,7 @@ jobs:
 
   write_docker_scout_info_comment:
     runs-on: ubuntu-latest
-    needs: ['build_and_test', 'build_k8s', 'build_windows_k8s']
+    needs: ['build_and_test', 'build_k8s']
     if: |
       !contains(needs.*.result, 'failure') &&
       github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+## v0.119.7
+- Fix CVE-2025-22866
+
 ## v0.119.6
 - Updates Go build toolchain to 1.23.6
 

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,12 +161,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver v0.119.6
+	github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver v0.119.7
 	github.com/spf13/cobra v1.8.1
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/confmap v1.26.0
@@ -587,8 +587,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.6 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.6 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.7 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.7 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider v0.119.0

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexport
 go 1.23.6
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.6
+	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.7
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0
@@ -42,7 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.6 // indirect
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/exporter/solarwindsexporter
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension v0.119.6

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsexten
 go 1.23.6
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.6
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.7
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/extension/solarwindsextension
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.6

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/internal/e2e
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/mdelapenya/tlscert v0.1.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/mdelapenya/tlscert v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.6
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.7
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	go.opentelemetry.io/collector/pdata v1.25.0

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -1,8 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.23.6
 
 require (
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.23.4
+go 1.23.6
 
 require github.com/google/addlicense v1.1.1
 

--- a/pkg/testutil/go.mod
+++ b/pkg/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/pkg/testutil
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,3 +1,3 @@
 module github.com/solarwinds/solarwinds-otel-collector/pkg/version
 
-go 1.23.4
+go 1.23.6

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.119.6"
+const Version = "0.119.7"

--- a/processor/k8seventgenerationprocessor/go.mod
+++ b/processor/k8seventgenerationprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/processor/k8seventgenerationprocessor
 
-go 1.23.0
+go 1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/receiver/swohostmetricsreceiver
 
-go 1.23.4
+go 1.23.6
 
 require (
 	github.com/go-ole/go-ole v1.3.0

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.6
-	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.6
+	github.com/solarwinds/solarwinds-otel-collector/pkg/testutil v0.119.7
+	github.com/solarwinds/solarwinds-otel-collector/pkg/version v0.119.7
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v0.119.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.6
+	github.com/solarwinds/solarwinds-otel-collector/internal/k8sconfig v0.119.7
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -1,8 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector/receiver/swok8sobjectsreceiver
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.23.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
#### Description
Increases toolchain used across all components to utilize Go 1.23.6 to mitigate CVE-2025-22866. 

Difference can be seen in this [docker scout report](https://github.com/solarwinds/solarwinds-otel-collector/actions/runs/13857076111) with explicitly enabled windows builds to validate the vulnerability is no longer present.
Prepares release 0.119.7 to bring the fix.

#### Testing
E2E pipeline.
