### PR TITLE
feature: #106 Ignore timestamps

### DIFF
--- a/receiver/swok8sobjectsreceiver/receiver.go
+++ b/receiver/swok8sobjectsreceiver/receiver.go
@@ -404,7 +404,7 @@ func getObjectHashes(udata *unstructured.Unstructured) (*objecthashes, error) {
 		return nil, err
 	}
 
-	timestampRegex := regexp.MustCompile(`/(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/`)
+	timestampRegex := regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})\b?`)
 
 	// do not report changes in any timestamps
 	cleanedBytes := timestampRegex.ReplaceAll(udataBytes, []byte(""))


### PR DESCRIPTION
Description
This PR ignores timestamps in all k8s manifests

Testing
Unit test `TestGetObjectHashesRemovesTimestamps`